### PR TITLE
Fixes formatting typo in cheatsheet.md

### DIFF
--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -95,7 +95,7 @@ Merge specified branch history into current branch:
 Stop merge in case of conflicts:  
 `git merge --abort`
 
-Bring a commit from another branch into current branch:
+Bring a commit from another branch into current branch:  
 `git cherry-pick [SHA]`
 
 


### PR DESCRIPTION
I forgot that a line requires double whitespaces before any
code formatting. Resolves #5 